### PR TITLE
Fix stale test

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ mod tests {
 
         assert_eq!(
             scan(strinput.as_bytes()).unwrap().into_iter().collect::<Vec<_>>(),
-            vec!["cmd: ip a", "ip: 127.0.0.1", "ip: ::1", "num: 1000", "num: 65536"],
+            vec!["cmd: ip a", "ip: 127.0.0.1", "ip: ::1", "mac: 00:00:00:00:00:00", "num: 1000", "num: 65536"],
         );
     }
 }


### PR DESCRIPTION
Looks like support for mac addresses were added but the unit test not updated. Just copy the current output of `scran` and put it in the test assertion.